### PR TITLE
Create 20210410m.m4a

### DIFF
--- a/_posts/2021-04-10-104.md
+++ b/_posts/2021-04-10-104.md
@@ -1,0 +1,53 @@
+---
+actor_ids:
+  - kokorokagami
+  - touden
+audio_file_path: /audio/20210410m.m4a
+audio_file_size: 0
+date: 2021-04-10 20:00:00 +0900
+description: kokorokagamiとtoudenの2人で、人事の遠藤さん、アクティブ音響センシング などについて話しました。
+duration: "00:00"
+layout: article
+title: 104. 2021/04/10 Sidekick Browser使ってみた
+---
+
+# [1. Sidekick Browser使ってみた](https://www.meetsidekick.com/) (00:05～)
+
+[<img src="https://uploads-ssl.webflow.com/5ebfcafe01722a44a9c588e0/5f771af8b994bcef3ab391f8_sidekick-logo.svg" width="320dp">](https://www.meetsidekick.com/)  
+
+# [2. 優秀すぎる人事社員は、実はこの世に存在しない人物だった……フルリモートワーク企業のある実話](https://www.businessinsider.jp/post-232547) (18:44～)
+
+[<img src="https://assets.media-platform.com/bi/dist/images/2021/04/06/shutterstock_1126786166.jpg" width="320dp">](https://www.businessinsider.jp/post-232547)  
+
+# [3. フォークを刺した音で食材が分かる　高精度な食事記録システムを立命館大が開発](https://www.itmedia.co.jp/news/articles/2104/05/news081.html) (36:12～)
+
+[<img src="https://image.itmedia.co.jp/news/articles/2104/05/koya_foodlog0.jpg" width="320dp">](https://www.itmedia.co.jp/news/articles/2104/05/news081.html)  
+
+# [4. 緒方洪庵が残した「開かずの薬瓶」、ミュー粒子で中身を特定 阪大など](https://news.yahoo.co.jp/articles/579e937fa62b4cdb966e30b92e6dd22824e47db8) (44:54～)
+
+[<img src="https://amd-pctr.c.yimg.jp/r/iwiz-amd/20210406-00010000-sportal-000-1-view.jpg?w=640&h=366&q=90&exp=10800&pri=l" width="320dp">](https://news.yahoo.co.jp/articles/579e937fa62b4cdb966e30b92e6dd22824e47db8)  
+
+___
+
+# こちらでも配信しています
+- [Youtube Live](https://www.youtube.com/channel/UCD1zo-WnyFdE5w0pqvKblkA)
+
+# ご意見、ご感想
+- [Twitter](https://twitter.com/recalog1)
+- [メールアドレス：recalog1@gmail.com](recalog1@gmail.com)
+
+# 編集
+
+@Touden氏  
+最大限の感謝を  
+
+# BGM
+
+[騒音のない世界](http://noiselessworld.net/) beco様より  
+OP:[オオカミ少年](https://soundcloud.com/baron1_3/wolfboy)  
+本編:[蜃気楼](https://soundcloud.com/baron1_3/shinkirou)  
+
+# 免責
+
+本ラジオはあくまで個人の見解であり現実のいかなる団体を代表するものではありません  
+ご理解頂ますようよろしくおねがいします  


### PR DESCRIPTION
やはりこちらのほうが安定する。

touden: AT2005,
kokorokagami: ATR2100X-USB,
cleanfeed, stereo spilit

(kokorokagami側)
・増幅（自動）
・ノイズ除去 10db S=6, F=1。
・コンプレッサ 閾値-15dB, ノイズフロア-80dB, レシオ10:1, アタックタイム0.1s, リリースタイム1.0s、ピークに基づく圧縮

(toudenのみ)
・増幅（自動）
・ノイズ除去 15db S=6, F=1。
・コンプレッサ 閾値-10dB, ノイズフロア-80dB, レシオ10:1, アタックタイム0.1s, リリースタイム1.0s、ピークに基づく圧縮

(両方)
・最初と最後をカット
・-6dBに増幅
・結合して出力

[結合したデータを編集]
・コンプレッサ 閾値-6dB, ノイズフロア-80dB, レシオ10:1, アタックタイム0.1s, リリースタイム1.0s、ピークに基づく圧縮
・無音除去 -35dB, >0.5s→0.5s

・wolf -30dBトラック追加
・shinkirou -27dBトラック追加

・M4a
・チャプター追加