### PR TITLE
Create 20210425m.m4a

### DIFF
--- a/_posts/2021-04-25-106.md
+++ b/_posts/2021-04-25-106.md
@@ -1,0 +1,54 @@
+---
+actor_ids:
+  - kokorokagami
+  - touden
+audio_file_path: /audio/20210425m.m4a
+audio_file_size: 0
+date: 2021-04-25 20:00:00 +0900
+description: kokorokagamiとtoudenの2人で、火星大気から酸素生成、火星待機でヘリコプター初飛行 などについて話しました。
+duration: "00:00"
+layout: article
+title: 106. 2021/04/25 クルードラゴンISSドッキング
+---
+
+# [1. スペースXが再利用Dragon宇宙船での宇宙飛行士の打ち上げに初成功](https://jp.techcrunch.com/2021/04/24/2021-04-23-spacex-successfully-launches-astronauts-with-a-re-used-dragon-spacecraft-for-the-first-time/) (00:05～)
+
+[<img src="https://jp.techcrunch.com/wp-content/uploads/2021/04/spacex-crew-2-launch.gif?w=738" width="320dp">](https://jp.techcrunch.com/2021/04/24/2021-04-23-spacex-successfully-launches-astronauts-with-a-re-used-dragon-spacecraft-for-the-first-time/)  
+
+# [2. NASAが初めて火星の大気からの酸素生成に成功、将来の有人探査に向けた実証実験](https://jp.techcrunch.com/2021/04/23/mars-rover-extracts-first-oxygen-from-mars/) (03:30～)
+
+[<img src="https://jp.techcrunch.com/wp-content/uploads/2021/04/moxie_being_installed_in_perseverance.jpg" width="320dp">](https://jp.techcrunch.com/2021/04/23/mars-rover-extracts-first-oxygen-from-mars/)  
+
+# [3. NASAが火星でのヘリコプター初飛行に成功、歴史にその名を刻む](https://jp.techcrunch.com/2021/04/20/2021-04-19-nasa-makes-history-by-flying-a-helicopter-on-mars-for-the-first-time/) (12:22～)
+
+[<img src="https://jp.techcrunch.com/wp-content/uploads/2021/04/1-anillustrati.jpeg?w=738" width="320dp">](https://jp.techcrunch.com/2021/04/20/2021-04-19-nasa-makes-history-by-flying-a-helicopter-on-mars-for-the-first-time/)  
+
+# [4. ホンダがロケット開発に参入を表明。公式発表からわかること、そして「小型ロケット」とは](https://news.yahoo.co.jp/byline/akiyamaayano/20210425-00234555/) (19:34～)
+
+[<img src="https://newsbyl-pctr.c.yimg.jp/r/iwiz-yn/rpr/akiyamaayano/00234555/title-1619340863588.jpeg" width="320dp">](https://news.yahoo.co.jp/byline/akiyamaayano/20210425-00234555/)  
+
+
+___
+
+# こちらでも配信しています
+- [Youtube Live](https://www.youtube.com/channel/UCD1zo-WnyFdE5w0pqvKblkA)
+
+# ご意見、ご感想
+- [Twitter](https://twitter.com/recalog1)
+- [メールアドレス：recalog1@gmail.com](recalog1@gmail.com)
+
+# 編集
+
+@Touden氏  
+最大限の感謝を  
+
+# BGM
+
+[騒音のない世界](http://noiselessworld.net/) beco様より  
+OP:[オオカミ少年](https://soundcloud.com/baron1_3/wolfboy)  
+本編:[蜃気楼](https://soundcloud.com/baron1_3/shinkirou)  
+
+# 免責
+
+本ラジオはあくまで個人の見解であり現実のいかなる団体を代表するものではありません  
+ご理解頂ますようよろしくおねがいします  


### PR DESCRIPTION
touden: AT2005,
kokorokagami: ATR2100X-USB,
cleanfeed, stereo spilit

(kokorokagami側)
・増幅（自動）
・ノイズ除去 15db S=6, F=1。
・コンプレッサ 閾値-10dB, ノイズフロア-80dB, レシオ10:1, アタックタイム0.1s, リリースタイム1.0s、ピークに基づく圧縮

(toudenのみ)
・増幅（自動）
・ノイズ除去 15db S=6, F=1。
・コンプレッサ 閾値-10dB, ノイズフロア-80dB, レシオ10:1, アタックタイム0.1s, リリースタイム1.0s、ピークに基づく圧縮

(両方)
・最初と最後をカット
・-6dBに増幅
・結合して出力

[結合したデータを編集]
・コンプレッサ 閾値-6dB, ノイズフロア-80dB, レシオ10:1, アタックタイム0.1s, リリースタイム1.0s、ピークに基づく圧縮
・無音除去 -35dB, >0.5s→0.5s

・wolf -30dBトラック追加
・shinkirou -27dBトラック追加

・M4a
・チャプター追加